### PR TITLE
Add Google credential helper

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/helper/credential.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/credential.rb
@@ -8,12 +8,10 @@ module Fastlane
       end
 
       def self.get_google_credential(scopes)
-        if @key_file_path
-          File.open(@key_file_path, "r") do |file|
-            return Google::Auth::ServiceAccountCredentials.read_json_key(file)
-          end
-        else
-          return Google::Auth.get_application_default(scopes)
+        return Google::Auth.get_application_default(scopes) unless @key_file_path
+
+        File.open(@key_file_path, "r") do |file|
+          return Google::Auth::ServiceAccountCredentials.read_json_key(file)
         end
       end
     end


### PR DESCRIPTION
I want to:

Pass an instance of this credential class, and those who own this object would be able to obtain a Google auth object by supplying its own distinct SCOPES.