### PR TITLE
Some bugfixes

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/helper/credential.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/credential.rb
@@ -11,7 +11,11 @@ module Fastlane
         return Google::Auth.get_application_default(scopes) unless @key_file_path
 
         File.open(@key_file_path, "r") do |file|
-          return Google::Auth::ServiceAccountCredentials.read_json_key(file)
+          options = {
+            json_key_io: file,
+            scope: scopes
+          }
+          return Google::Auth::ServiceAccountCredentials.make_creds(options)
         end
       end
     end

--- a/lib/fastlane/plugin/firebase_test_lab/helper/ftl_service.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ftl_service.rb
@@ -84,7 +84,7 @@ module Fastlane
           },
           environmentMatrix: {
             iosDeviceList: {
-              iosDevices: devices.map(self.map_device_to_proto)
+              iosDevices: devices.map(&FirebaseTestLabService.method(:map_device_to_proto))
             }
           },
           resultStorage: {
@@ -111,6 +111,10 @@ module Fastlane
 
         if resp.status != 200
           FastlaneCore::UI.error("Failed to start Firebase Test Lab jobs.")
+          FastlaneCore::UI.error("Hint: Have you enrolled in Firebase Test Lab iOS beta tester program? It is " \
+                                 "required during the beta testing. Click https://docs.google.com" \
+                                 "/forms/d/e/1FAIpQLSf5cx1ot8ndHU9YrFkCn6gPoQZLxgW_6H13e_bot3he90n7Ng/viewform " \
+                                 "to request access.")
           FastlaneCore::UI.error(resp.body)
           return nil
         else


### PR DESCRIPTION
1. make_creds is the right method to generate a Google key object.
2. the map function does not reference to the correct method. 
3. Add a hint to firebase test lab failure to point the user to enroll in beta test.

PTAL