### PR TITLE
Default to read app path from lane context

### DIFF
--- a/fastlane-plugin-firebase_test_lab.gemspec
+++ b/fastlane-plugin-firebase_test_lab.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'tty-spinner', '>= 0.8.0', '< 1.0.0'
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'fastlane', '>= 2.101.0'
+  spec.add_development_dependency 'fastlane', '>= 2.102.0'
 end

--- a/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
@@ -111,9 +111,9 @@ module Fastlane
 
           state = results["state"]
           # Handle all known error statuses
-          if ERROR_STATE_TO_MESSAGE.key?(state)
+          if ERROR_STATE_TO_MESSAGE.key?(state.to_sym)
             spinner.error("Failed")
-            UI.user_error!(ERROR_STATE_TO_MESSAGE[state])
+            UI.user_error!(ERROR_STATE_TO_MESSAGE[state.to_sym])
             return false
           end
 

--- a/lib/fastlane/plugin/firebase_test_lab/options.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/options.rb
@@ -10,6 +10,9 @@ module Fastlane
                                        optional: false),
           FastlaneCore::ConfigItem.new(key: :app_path,
                                        description: "Path to the app, either on the filesystem or GCS address (gs://)",
+                                       default_value:
+                                         Actions.lane_context[Actions::SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH],
+                                       optional: true,
                                        verify_block: proc do |value|
                                          unless value.to_s.start_with?("gs://")
                                            v = File.expand_path(value.to_s)


### PR DESCRIPTION
Have this code for a while but forgot to push. This PR:
1. Accept the app_path from build context when you use scan to build the app.
2. Fix some error message issues.
3. Update the version requirement to match the fastlane version that introduced the scan build context for scan.