### PR TITLE
Fail the job when at least 1 test case fails

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
@@ -126,13 +126,14 @@ module Fastlane
             executions_completed = extract_execution_results(results)
 
             if results["resultStorage"].nil? || results["resultStorage"]["toolResultsExecution"].nil?
-              UI.abort_with_message!("Unexpected error: Cannot retrieve result info")
+              UI.abort_with_message!("Unexpected response from Firebase test lab: Cannot retrieve result info")
             end
 
             # Now, look at the actual test result and see if they succeed
             history_id, execution_id = try_get_history_id_and_execution_id(results)
             if history_id.nil? || execution_id.nil?
-              FastlaneCore::UI.abort_with_message!("Unexpected response: No history ID or execution ID")
+              FastlaneCore::UI.abort_with_message!("Unexpected response from Firebase test lab: No history or " \
+                                                   "execution ID")
             end
             test_results = ftl_service.get_execution_steps(gcp_project, history_id, execution_id)
             tests_successful = extract_test_results(test_results, gcp_project, history_id, execution_id)


### PR DESCRIPTION
This PR changes the plugin so it no longer returns true or false as the result, but ensure that any failure will raise an exception, so that the build gets failed.

Also change to have two spaces after emoji: https://github.com/fastlane/fastlane-plugin-firebase_test_lab/issues/33