### PR TITLE
Catch all exceptions when obtaining Google access token

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/helper/credential.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/credential.rb
@@ -11,7 +11,7 @@ module Fastlane
         unless @key_file_path
           begin
             return Google::Auth.get_application_default(scopes)
-          rescue Error => ex
+          rescue => ex
             UI.abort_with_message!("Failed reading application default credential. Either the Oauth credential should be provided or Google Application Default Credential should be configured: #{ex.message}")
           end
         end
@@ -23,7 +23,7 @@ module Fastlane
           }
           begin
             return Google::Auth::ServiceAccountCredentials.make_creds(options)
-          rescue Error => ex
+          rescue => ex
             UI.abort_with_message!("Failed reading OAuth credential: #{ex.message}")
           end
         end


### PR DESCRIPTION
Ruby 2.0 supports this grammar. It should catch any exception and show user-friendly message.