### PR TITLE
Xcode 10.1.0 fix

### DIFF
--- a/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
@@ -14,7 +14,14 @@ module Fastlane
             end
 
             conf = Plist.parse_xml(xctestrun_files.first.get_input_stream)
-            _, scheme_conf = conf.first
+            size = conf.size
+            if conf['__xctestrun_metadata__']
+              size -= 1
+            end  
+            unless size == 1
+                UI.user_error!("The app bundle may contain only one scheme, #{size} found")
+            end
+             _, scheme_conf = conf.first
             unless scheme_conf["IsUITestBundle"]
               UI.user_error!("The app bundle is not a UI test bundle. Did you build with build-for-testing argument?")
             end

--- a/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
@@ -13,10 +13,6 @@ module Fastlane
               UI.user_error!("app verification failed: There must be only one .xctestrun files in the ZIP file.")
             end
 
-            # conf = Plist.parse_xml(xctestrun_files.first.get_input_stream)
-            # unless conf.size == 1
-            #   UI.user_error!("The app bundle may contain only one scheme, #{conf.size} found")
-            # end
             _, scheme_conf = conf.first
             unless scheme_conf["IsUITestBundle"]
               UI.user_error!("The app bundle is not a UI test bundle. Did you build with build-for-testing argument?")

--- a/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
@@ -13,10 +13,10 @@ module Fastlane
               UI.user_error!("app verification failed: There must be only one .xctestrun files in the ZIP file.")
             end
 
-            conf = Plist.parse_xml(xctestrun_files.first.get_input_stream)
-            unless conf.size == 1
-              UI.user_error!("The app bundle may contain only one scheme, #{conf.size} found")
-            end
+            # conf = Plist.parse_xml(xctestrun_files.first.get_input_stream)
+            # unless conf.size == 1
+            #   UI.user_error!("The app bundle may contain only one scheme, #{conf.size} found")
+            # end
             _, scheme_conf = conf.first
             unless scheme_conf["IsUITestBundle"]
               UI.user_error!("The app bundle is not a UI test bundle. Did you build with build-for-testing argument?")

--- a/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
@@ -19,9 +19,9 @@ module Fastlane
               size -= 1
             end  
             unless size == 1
-                UI.user_error!("The app bundle may contain only one scheme, #{size} found")
+              UI.user_error!("The app bundle may contain only one scheme, #{size} found")
             end
-             _, scheme_conf = conf.first
+            _, scheme_conf = conf.first
             unless scheme_conf["IsUITestBundle"]
               UI.user_error!("The app bundle is not a UI test bundle. Did you build with build-for-testing argument?")
             end

--- a/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/ios_validator.rb
@@ -13,6 +13,7 @@ module Fastlane
               UI.user_error!("app verification failed: There must be only one .xctestrun files in the ZIP file.")
             end
 
+            conf = Plist.parse_xml(xctestrun_files.first.get_input_stream)
             _, scheme_conf = conf.first
             unless scheme_conf["IsUITestBundle"]
               UI.user_error!("The app bundle is not a UI test bundle. Did you build with build-for-testing argument?")

--- a/lib/fastlane/plugin/firebase_test_lab/module.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/module.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module FirebaseTestLab
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
     PLUGIN_NAME = "fastlane-plugin-firebase_test_lab"
   end
 end


### PR DESCRIPTION
Since XCode 10.1.0 the 'scheme count' counts one scheme more then exists, but the check is not necessary at all, so it's removed.

This solves bug issue #54 