### PR TITLE
Link to Firebase Test Lab matrix-id for `Tests failed`

### DIFF
--- a/fastlane-plugin-firebase_test_lab.gemspec
+++ b/fastlane-plugin-firebase_test_lab.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('googleauth')
   spec.add_dependency('rubyzip', '>= 1.0.0')
   spec.add_dependency('plist', '>= 3.0.0')
-  spec.add_dependency('google-cloud-storage', '~> 1.13.0')
+  spec.add_dependency('google-cloud-storage', '~> 1.15.0')
   spec.add_dependency('tty-spinner', '>= 0.8.0', '< 1.0.0')
 
   spec.add_development_dependency('bundler')

--- a/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/actions/firebase_test_lab_ios_xctest.rb
@@ -136,7 +136,8 @@ module Fastlane
             test_results = ftl_service.get_execution_steps(gcp_project, history_id, execution_id)
             tests_successful = extract_test_results(test_results, gcp_project, history_id, execution_id)
             unless executions_completed && tests_successful
-              UI.test_failure!("Tests failed")
+              UI.test_failure!("Tests failed. " \
+                "Go to #{firebase_console_link} for more information about this run")
             end
             return
           end

--- a/lib/fastlane/plugin/firebase_test_lab/module.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/module.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module FirebaseTestLab
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
     PLUGIN_NAME = "fastlane-plugin-firebase_test_lab"
   end
 end


### PR DESCRIPTION
With this we are able to get a link to the failed test matrix from fastlane in stead of only showing _Tests failed_.

_Tests failed. Go to https://console.firebase.google.com/project/your-app-12345/testlab/histories/bh.1f035de68cd206ce/matrices/1234752491547013142 for more information about this run_