### PR TITLE
Added the option to specify Google Cloud requests timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ firebase_test_lab_ios_xctest(
 
 - `app_path`: You may provide a different path in the local filesystem (e.g: `/path/to/app-bundle.zip`) or on Google Cloud Storage (`gs://your-bucket/path/to/app-bundle.zip`) that points to an app bundle as specified [here](https://firebase.google.com/docs/test-lab/ios/command-line#build_xctests_for_your_app). If a Google Cloud Storage path is used, the service account must have read access to such file.
 - `gcp_project`: The Google Cloud project name for Firebase Test Lab to run on.
+- `gcp_requests_timeout`: The timeout, in seconds, to use for all requests to the Google Cloud platform (e.g. uploading your app bundle ZIP). If this parameter is omitted, Google Cloud SDK's default requests timeout value will be used. If you are finding that your ZIP uploads are timing out due to the ZIP file being large and not completing within the set timeout time, increase this value.
 - `oauth_key_file_path`: The path to the Google Cloud service account key. If not set, the Google application default credential will be used.
 - `devices`: An array of devices for your app to be tested on. Each device is represented as a ruby hash, with `ios_model_id`, `ios_version_id`, `locale` and `orientation` properties, the first two of which are required. If not set, it will default to iPhone X on iOS 11.2. This array cannot be empty.
 - `async`: If set to true, the action will not wait for the test results but exit immediately.

--- a/lib/fastlane/plugin/firebase_test_lab/helper/storage.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/helper/storage.rb
@@ -8,10 +8,11 @@ module Fastlane
 
       private_constant :GCS_OAUTH_SCOPES
 
-      def initialize(gcp_project, credential)
+      def initialize(gcp_project, credential, gcp_requests_timeout)
         credentials = credential.get_google_credential(GCS_OAUTH_SCOPES)
         @client = Google::Cloud::Storage.new(project_id: gcp_project,
-                                             credentials: credentials)
+                                             credentials: credentials,
+                                             timeout: gcp_requests_timeout)
       end
 
       def upload_file(source_path, destination_bucket, destination_path)

--- a/lib/fastlane/plugin/firebase_test_lab/module.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/module.rb
@@ -1,6 +1,6 @@
 module Fastlane
   module FirebaseTestLab
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
     PLUGIN_NAME = "fastlane-plugin-firebase_test_lab"
   end
 end

--- a/lib/fastlane/plugin/firebase_test_lab/options.rb
+++ b/lib/fastlane/plugin/firebase_test_lab/options.rb
@@ -8,6 +8,9 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :gcp_project,
                                        description: "Google Cloud Platform project name",
                                        optional: false),
+          FastlaneCore::ConfigItem.new(key: :gcp_requests_timeout,
+                                       description: "The timeout (in seconds) to use for all Google Cloud requests (such as uploading your tests ZIP)",
+                                       optional: true),
           FastlaneCore::ConfigItem.new(key: :app_path,
                                        description: "Path to the app, either on the filesystem or GCS address (gs://)",
                                        default_value:


### PR DESCRIPTION
Hey! John here again. My PR for 1.0.1 works a charm, and I got Google to fix the issue on their end. Turns out their validator had exactly the same bug as plugin version 1.0.1's validator!

## What?

I have added an option that can be passed when calling the plugin, `requests_timeout`, that will set the requests timeout when uploading the build products to Google Cloud storage.

Our build products ZIP output from fastlane is a whopping 522 MB! Even with our fast internet connection, I found that the upload to Google Cloud Storage was timing out. It produces an error line this:

`[12:38:19]: execution expired`

[Best Practices for Google Cloud Storage, Uploading data](https://cloud.google.com/storage/docs/best-practices#uploading) specifies that "for upload traffic, we recommend setting reasonably long timeouts". 

It's unclear what the default timeout is for requests when attempting an upload, but it may not always be sufficient.

## How?

Specifying `requests_timeout` will pass the given timeout interval, in seconds, when creating the `Google::Cloud::Storage` instance. If no timeout is passed, `nil` will be given as the timeout to use whatever the default timeout is.

## Questions

- Should we hardcode a default timeout for improved clarity when using the plugin? Perhaps a sensible value of 10 minutes or so, to cater for the upload.

I'm not a Ruby programmer, so by all means please suggest improvements to this PR.