### PR TITLE
Version bump google-cloud-storage

### DIFF
--- a/fastlane-plugin-firebase_test_lab.gemspec
+++ b/fastlane-plugin-firebase_test_lab.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency('googleauth')
   spec.add_dependency('rubyzip', '>= 1.0.0')
   spec.add_dependency('plist', '>= 3.0.0')
-  spec.add_dependency('google-cloud-storage', '>= 1.25.1', '<2.0.0')
+  spec.add_dependency('google-cloud-storage', '>= 1.31', '<2.0.0')
   spec.add_dependency('tty-spinner', '>= 0.8.0', '< 1.0.0')
 
   spec.add_development_dependency('bundler')


### PR DESCRIPTION
Since versions before fastlane 2.188.0 broke due to changes in Apple authentication policies, this plugin won't install due to google-cloud-storage dependency version, so I changed to 1.31 so that it can install newer versions of fastlane